### PR TITLE
feat: Nullcat chan(botの取説)のページ作る #3 close

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,6 +4,11 @@ body {
     color: map-get($nyanCS, "white");
 }
 
+// github markdown css
+.markdown-body {
+    pre > code { color: map-get($nyanCS, "brightBlue")  !important }
+}
+
 @each $key, $color in $nyanCS {
     .color-bg-#{$key} {
         background-color: #{$color};

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -22,6 +22,7 @@ export default {
   // Global CSS: https://go.nuxtjs.dev/config-css
   css: [
     "~/assets/css/main.scss",
+    "github-markdown-css",
   ],
 
   // Plugins to run before rendering page: https://go.nuxtjs.dev/config-plugins

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "bootstrap": "^4.6.1",
     "bootstrap-vue": "^2.21.2",
     "core-js": "^3.19.3",
+    "github-markdown-css": "^5.1.0",
+    "marked": "^4.0.12",
     "nuxt": "^2.15.8",
     "pug": "^3.0.2",
     "pug-loader": "^2.4.0",

--- a/pages/nullcat-chan/index.vue
+++ b/pages/nullcat-chan/index.vue
@@ -1,0 +1,42 @@
+<template lang="pug">
+  .markdown-body.color-bg-backgroundBlue.p-4(v-html="markdownToHtml()")
+</template>
+
+<script lang="ts">
+import Vue from "vue"
+import Component from "vue-class-component"
+import { marked } from "marked"
+
+@Component
+export default class NullcatChanPage extends Vue
+{
+  public content = ""
+
+  private async fetch()
+  {
+    const apiUrl = "https://api.github.com"
+    const repoUrl = "/repos/NullCatSlave/Nullcatchan"
+
+    const headers = {
+      Accept: "application/vnd.github.v3+json",
+    }
+
+    const response = await fetch(`${apiUrl}${repoUrl}/contents/torisetu.md`, { headers })
+
+    if (response.status !== 200) throw new Error("正常にデータを取得できませんでした。")
+
+    const data = await response.json()
+    this.content = Buffer.from(data.content, "base64").toString()
+  }
+
+  public markdownToHtml()
+  {
+    return marked(this.content)
+  }
+
+  async created()
+  {
+    await this.fetch()
+  }
+}
+</script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -5555,6 +5555,11 @@ git-url-parse@^11.4.4:
   dependencies:
     git-up "^4.0.0"
 
+github-markdown-css@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/github-markdown-css/-/github-markdown-css-5.1.0.tgz#a96281cd90a8969e3c13b9d3ca6a733a523a00a6"
+  integrity sha512-QLtORwHHtUHhPMHu7i4GKfP6Vx5CWZn+NKQXe+cBhslY1HEt0CTEkP4d/vSROKV0iIJSpl4UtlQ16AD8C6lMug==
+
 glob-parent@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
@@ -7070,6 +7075,11 @@ map-visit@^1.0.0:
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
+
+marked@^4.0.12:
+  version "4.0.12"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.12.tgz#2262a4e6fd1afd2f13557726238b69a48b982f7d"
+  integrity sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==
 
 md5.js@^1.3.4:
   version "1.3.5"


### PR DESCRIPTION
## やったこと
- Botの取扱説明書Pageを追加
  - github apiから[torisetu.md](https://github.com/NullCatSlave/Nullcatchan/blob/master/torisetu.md) のMarkdownを取得
  - `marked` を使ってhtmlに変換



- github markdown css関係
  - https://bitto.jp/posts/blog/nuxt%E5%8C%96/md-on-bulma/
  - `assets/css/main.scss` ←dark modeのときの複数行Snippetのときのcolorがいまいちだったので追加

## 相談したいこと
1. `/nullcat-chan` に直遷移しないと見れないはず（内部リンク追加する必要がありそう）
2. タイトル（NullCat chan botの~、など）やtorisetu.md のリンク（一次情報）が必要かも
3. `main.scss` に追加したやつ、scopedにしてない（scopedにすると動かない）ので他のコード・ファイルで影響が出るかも（現状出てないけど）

## 動作確認
1. git cloneして git pull
2. `localhost:3000/nullcat-chan` に遷移
3. 見れるはず

Co-authored-by: あずき⪥™ <hijiki02@users.noreply.github.com>
Co-authored-by: NullCat <nullnyat@outlook.com>