### PR TITLE
feat: /nullcat-chan add container, add link in header

### DIFF
--- a/components/BaseHeader.vue
+++ b/components/BaseHeader.vue
@@ -12,4 +12,7 @@
             a.nav-link.color-fg-white(href="#about") About
           li: .nav-item
             a.nav-link.color-fg-white(href="#links") Links
+          li: .nav-item
+            a.nav-link.color-fg-white(href="/nullcat-chan")
+              img.mb-2.mr-0.mb-md-0.mr-md-2(alt="Nullcat chan", width="40", src="@/assets/img/nullcat/hi_nullcat.png")
 </template>

--- a/pages/nullcat-chan/index.vue
+++ b/pages/nullcat-chan/index.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
-  .markdown-body.color-bg-backgroundBlue.p-4(v-html="markdownToHtml()")
+  .markdown-body.color-bg-backgroundBlue.p-4
+    .container(v-html="markdownToHtml()")
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
## やったこと
- BaseHeaderにNullCat chan botのリンクを追加
- `/nullcat-chan` に`.container`を追加して両サイドに余白ができるようにした